### PR TITLE
Fix 40

### DIFF
--- a/content/7-modern-contemporary/40.md
+++ b/content/7-modern-contemporary/40.md
@@ -219,7 +219,7 @@ Our conclusions fall into two categories: those that have practical ramification
 
 [^1]: *Surfacing* refers to the development at the surface of a painting of a deformation that corresponds to the shape of a local repair applied to the verso of the painting, such as a patch.
 
-[^2]: Timoshenko derived the curvature of any two-layer laminate with differential shrinkage. If the differential shrinkage is (ε~1−~ε~2~), m is the ratio of the two thicknesses, n is the ratio of the two moduli of elasticity, and t is the laminate thickness, then radius of curvature is R=(t\*(3\*(1+m)\^2+(1+m\*n)\*(m\^2+1/(m\*n))))/(6\*(ε~1−~ε~2~)\*(1+m)\^2). The height h of the arc over a base of w and curvature R is h=R-(R\^2-w\^2). See [https://www.mathopenref.com/sagitta.html](https://www.mathopenref.com/sagitta.html).
+[^2]: Timoshenko derived the curvature of any two-layer laminate with differential shrinkage. If the differential shrinkage is (ε<sub>1</sub>−ε<sub>2</sub>), m is the ratio of the two thicknesses, n is the ratio of the two moduli of elasticity, and t is the laminate thickness, then radius of curvature is R=(t\*(3\*(1+m)\^2+(1+m\*n)\*(m\^2+1/(m\*n))))/(6\*(ε<sub>1</sub>−ε<sub>2</sub>)\*(1+m)\^2). The height h of the arc over a base of w and curvature R is h=R-(R\^2-w\^2). See [https://www.mathopenref.com/sagitta.html](https://www.mathopenref.com/sagitta.html).
 
 [^3]: Given initial values of m=n=1 (see previous note) a plot of h stays within 25% of initial value despite changes in thickness ratio, n, by a factor of 3, or changes in elasticity ratio, m, by a factor of 7. Heavy impasto, or paints known to be soft, such as poor driers, will need the full equation, rather than the graph of [fig. 40.1](#fig-40-1).
 


### PR DESCRIPTION
This pull is only for subscripts in the formula in the footnote on page 40. It can be deleted if these subscripts have already been applied.